### PR TITLE
documentation edits + items in all Latin languages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<artifactId>grb</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>Game Resource Bot</name>
-	<description>some test bot</description>
+	<description>a Discord bot for managing guild resources</description>
 
 	<repositories>
 		<repository>
@@ -23,7 +23,7 @@
 	</repositories>
 
 	<dependencies>
-		<!-- discord stuff -->
+		<!-- Discord stuff -->
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
@@ -34,7 +34,7 @@
 			<artifactId>JDA</artifactId>
 			<version>3.2.0_242</version>
 		</dependency>
-		<!-- Hibernate library dependecy start -->
+		<!-- start Hibernate library dependency -->
 		<dependency>
 			<groupId>com.google.inject</groupId>
 			<artifactId>guice</artifactId>
@@ -53,7 +53,7 @@
 			<artifactId>postgresql</artifactId>
 			<version>9.4.1211</version>
 		</dependency>
-		<!-- Hibernate library dependency end -->
+		<!-- end Hibernate library dependency -->
 		<!-- utility stuff -->
 		<dependency>
 			<groupId>org.apache.commons</groupId>
@@ -194,7 +194,6 @@
 			<version>4.4</version>
 			<scope>test</scope>
 		</dependency>
-
 	</dependencies>
 
 	<properties>
@@ -203,7 +202,7 @@
 
 	<build>
 		<resources>
-			<!-- The resources in the lib folder -->
+			<!-- the resources in the lib folder -->
 			<resource>
 				<directory>tessdata</directory>
 				<includes>
@@ -212,7 +211,7 @@
 				<targetPath>${project.build.directory}/tessdata/</targetPath>
 				<filtering>false</filtering>
 			</resource>
-			<!-- We need to redeclare the project resources again -->
+			<!-- We need to redeclare the project resources. -->
 			<resource>
 				<directory>src/main/resources</directory>
 				<filtering>true</filtering>
@@ -265,6 +264,4 @@
 			</plugin>
 		</plugins>
 	</build>
-
-
 </project>

--- a/src/main/resources/items.xml
+++ b/src/main/resources/items.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
 <properties>
+	<!-- resources for mobile game "Deep Town"
+		English -->
 	<entry key="ACCUMULATOR">Accumulator</entry>
 	<entry key="ALEXANDRITE">Alexandrite</entry>
 	<entry key="ALUMINIUM">Aluminium</entry>
@@ -44,7 +46,7 @@
 	<entry key="GREEN_LASER">Green Laser</entry>
 	<entry key="GUNPOWDER">Gunpowder</entry>
 	<entry key="HAIR_COMB">Haircomb</entry>
-	<entry key="HELIUM_3">Helium-3</entry>
+	<entry key="HELIUM_3">Helium 3</entry>
 	<entry key="HYDROGEN">Hydrogen</entry>
 	<entry key="INSULATED_WIRE">Insulated Wire</entry>
 	<entry key="IRON">Iron</entry>
@@ -104,3 +106,4 @@
 	<entry key="WOOD">Tree</entry>
 	<entry key="YELLOW_CANDY">Yellow Candy</entry>
 </properties>
+

--- a/src/main/resources/items_de.xml
+++ b/src/main/resources/items_de.xml
@@ -2,8 +2,8 @@
 <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
 <properties>
 	<!-- Ressourcen für das Handy-Spiel "Deep Town"
-		Deutsch
-	resources for mobile game "Deep Town"
+		Deutsch -->
+	<!-- resources for mobile game "Deep Town"
 		German -->
 	<entry key="ACCUMULATOR">Akkumulator</entry>
 	<entry key="ALEXANDRITE">Alexandrit</entry>
@@ -17,7 +17,7 @@
 	<entry key="AMETHYST">Amethyst</entry>
 	<entry key="BATTERY">Batterie</entry>
 	<entry key="BOMB">Bombe</entry>
-	<entry key="CANDY_BATCH">Schachtel mit Süssigkeiten</entry>
+	<entry key="CANDY_BATCH">Schachtel mit Süßigkeiten</entry>
 	<entry key="CARVED_PUMPKIN">Geschnitzter Kürbis</entry>
 	<entry key="CIRCUIT">Schaltkreise</entry>
 	<entry key="CLEAN_WATER">Sauberes Wasser</entry>
@@ -44,11 +44,11 @@
 	<entry key="GRAPE">Traube</entry>
 	<entry key="GRAPE_SEED">Traubenkern</entry>
 	<entry key="GRAPHITE">Graphit</entry>
-	<entry key="GREEN_CANDY">Grüne Süssigkeit</entry>
+	<entry key="GREEN_CANDY">Grüne Süßigkeit</entry>
 	<entry key="GREEN_LASER">Grüner Laser</entry>
-	<entry key="GUNPOWDER">Schiesspulver</entry>
+	<entry key="GUNPOWDER">Schießpulver</entry>
 	<entry key="HAIR_COMB">Haarkamm</entry>
-	<entry key="HELIUM_3">Helium-3</entry>
+	<entry key="HELIUM_3">Helium 3</entry>
 	<entry key="HYDROGEN">Wasserstoff</entry>
 	<entry key="INSULATED_WIRE">Isolierter Draht</entry>
 	<entry key="IRON">Eisen</entry>
@@ -78,7 +78,7 @@
 	<entry key="POLISHED_SAPPHIRE">Polierter Saphir</entry>
 	<entry key="POLISHED_TOPAZ">Polierter Topas</entry>
 	<entry key="PUMPKIN">Kürbis</entry>
-	<entry key="RED_CANDY">Rote Süssigkeit</entry>
+	<entry key="RED_CANDY">Rote Süßigkeit</entry>
 	<entry key="REFINED_OIL">Raffiniertes Öl</entry>
 	<entry key="RUBBER">Gummi</entry>
 	<entry key="RUBY">Rubin</entry>
@@ -87,7 +87,7 @@
 	<entry key="SILICON">Silizium</entry>
 	<entry key="SILVER">Silber</entry>
 	<entry key="SILVER_BAR">Silberbarren</entry>
-	<entry key="SOCK_OF_CANDIES">Strumpf mit Süssigkeiten</entry>
+	<entry key="SOCK_OF_CANDIES">Strumpf mit Süßigkeiten</entry>
 	<entry key="SODIUM">Natrium</entry>
 	<entry key="SOLAR_PANEL">Solaranlage</entry>
 	<entry key="SOLID_PROPELLANT">Fester Treibstoff</entry>
@@ -106,5 +106,6 @@
 	<entry key="WINTERFEST_GLOBE">Wintertale-Globus</entry>
 	<entry key="WINTERFEST_TOY">Winterfest-Spielzeug</entry>
 	<entry key="WOOD">Holz</entry>
-	<entry key="YELLOW_CANDY">Gelbe Süssigkeit</entry>
+	<entry key="YELLOW_CANDY">Gelbe Süßigkeit</entry>
 </properties>
+

--- a/src/main/resources/items_en.xml
+++ b/src/main/resources/items_en.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
 <properties>
+	<!-- resources for mobile game "Deep Town"
+		English -->
 	<entry key="ACCUMULATOR">Accumulator</entry>
 	<entry key="ALEXANDRITE">Alexandrite</entry>
 	<entry key="ALUMINIUM">Aluminium</entry>
@@ -44,7 +46,7 @@
 	<entry key="GREEN_LASER">Green Laser</entry>
 	<entry key="GUNPOWDER">Gunpowder</entry>
 	<entry key="HAIR_COMB">Haircomb</entry>
-	<entry key="HELIUM_3">Helium-3</entry>
+	<entry key="HELIUM_3">Helium 3</entry>
 	<entry key="HYDROGEN">Hydrogen</entry>
 	<entry key="INSULATED_WIRE">Insulated Wire</entry>
 	<entry key="IRON">Iron</entry>
@@ -104,3 +106,4 @@
 	<entry key="WOOD">Tree</entry>
 	<entry key="YELLOW_CANDY">Yellow Candy</entry>
 </properties>
+

--- a/src/main/resources/items_es.xml
+++ b/src/main/resources/items_es.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
 <properties>
-	<!-- recursos para el juego de teléfono móvil "Deep Town"
-		Español
-	resources for mobile game "Deep Town"
+	<!-- resources for mobile game "Deep Town"
 		Spanish -->
+	<!-- ALL TRANSLATIONS MATCH THE GAME. TRANSLATIONS MAY OR MAY
+		NOT BE ACCURATE IN SPANISH. -->
 	<entry key="ACCUMULATOR">Acumulador</entry>
-	<!-- The translation for Alexandrite, below, is incorrect, but matches the game.
-	The correct translation is "Alejandrita". -->
 	<entry key="ALEXANDRITE">Alexandrino</entry>
 	<entry key="ALUMINIUM">Aluminio</entry>
 	<entry key="ALUMINIUM_BAR">Barra de Aluminio</entry>
@@ -15,7 +13,7 @@
 	<entry key="AMBER">Ámbar</entry>
 	<entry key="AMBER_BRACELET">Brazalete Ámbar</entry>
 	<entry key="AMBER_CHARGER">Cargador Ámbar</entry>
-	<entry key="AMBER_INSULATION">Aislante Ámbar</entry>
+	<entry key="AMBER_INSULATION"> Aislante Ámbar</entry>
 	<entry key="AMETHYST">Amatista</entry>
 	<entry key="BATTERY">Batería</entry>
 	<entry key="BOMB">Bomba</entry>
@@ -50,19 +48,17 @@
 	<entry key="GREEN_LASER">Láser Verde</entry>
 	<entry key="GUNPOWDER">Pólvora</entry>
 	<entry key="HAIR_COMB">Peine</entry>
-	<entry key="HELIUM_3">Helio-3</entry>
+	<entry key="HELIUM_3">Helio 3</entry>
 	<entry key="HYDROGEN">Hidrógeno</entry>
 	<entry key="INSULATED_WIRE">Cable Aislado</entry>
 	<entry key="IRON">Hierro</entry>
 	<entry key="IRON_BAR">Barra de Hierro</entry>
-	<entry key="LAMP">Lampara</entry>
+	<entry key="LAMP">Lámpara</entry>
 	<entry key="LIANA">Liana</entry>
 	<entry key="LIANA_SEED">Semilla de Liana</entry>
 	<entry key="LIQUID_NITROGEN">Nitrógeno Líquido</entry>
 	<entry key="MAGIC_BOX">Caja Mágica</entry>
 	<entry key="MAYAN_CALENDAR">Calendario Maya</entry>
-	<!-- The translation for Motherboard, below is incorrect, but matches the game.
-	The correct translation is "Placa Base". -->
 	<entry key="MOTHERBOARD">Tarjeta Madre</entry>
 	<entry key="NITROGEN">Nitrógeno</entry>
 	<entry key="OBSIDIAN">Obsidiana</entry>
@@ -78,9 +74,9 @@
 	<entry key="POLISHED_DIAMOND">Diamante Pulido</entry>
 	<entry key="POLISHED_EMERALD">Esmeralda Pulida</entry>
 	<entry key="POLISHED_OBSIDIAN">Obsidiana Pulida</entry>
-	<entry key="POLISHED_RUBY">Rubí Polido</entry>
+	<entry key="POLISHED_RUBY">Rubí Pulido</entry>
 	<entry key="POLISHED_SAPPHIRE">Safiro Pulido</entry>
-	<entry key="POLISHED_TOPAZ">Tapacio Pulido</entry>
+	<entry key="POLISHED_TOPAZ">Topacio Pulido</entry>
 	<entry key="PUMPKIN">Calabaza</entry>
 	<entry key="RED_CANDY">Caramelo Rojo</entry>
 	<entry key="REFINED_OIL">Petróleo Refinado</entry>

--- a/src/main/resources/items_fr.xml
+++ b/src/main/resources/items_fr.xml
@@ -2,8 +2,8 @@
 <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
 <properties>
 	<!-- ressources pour le jeu de téléphone portable "Deep Town"
-		Français
-	resources for mobile game "Deep Town"
+		Français -->
+	<!-- resources for mobile game "Deep Town"
 		French -->
 	<entry key="ACCUMULATOR">Accumulateur</entry>
 	<entry key="ALEXANDRITE">Alexandrite</entry>

--- a/src/main/resources/items_fr.xml
+++ b/src/main/resources/items_fr.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
 <properties>
-	<!-- ressources pour le jeu de téléphone portable "Deep Town"
-		Français -->
 	<!-- resources for mobile game "Deep Town"
 		French -->
+	<!-- ALL TRANSLATIONS MATCH THE GAME. TRANSLATIONS MAY OR MAY
+		NOT BE ACCURATE IN FRENCH. -->
 	<entry key="ACCUMULATOR">Accumulateur</entry>
 	<entry key="ALEXANDRITE">Alexandrite</entry>
 	<entry key="ALUMINIUM">Aluminium</entry>
@@ -46,9 +46,9 @@
 	<entry key="GRAPHITE">Graphite</entry>
 	<entry key="GREEN_CANDY">Bonbon Vert</entry>
 	<entry key="GREEN_LASER">Laser Vert</entry>
-	<entry key="GUNPOWDER">Poudre à Canon</entry>
+	<entry key="GUNPOWDER">Poudre À Canon</entry>
 	<entry key="HAIR_COMB">Peigne</entry>
-	<entry key="HELIUM_3">Hélium-3</entry>
+	<entry key="HELIUM_3">Hélium 3</entry>
 	<entry key="HYDROGEN">Hydrogène</entry>
 	<entry key="INSULATED_WIRE">Câble Isolé</entry>
 	<entry key="IRON">Fer</entry>
@@ -57,7 +57,7 @@
 	<entry key="LIANA">Liane</entry>
 	<entry key="LIANA_SEED">Graine de Liane</entry>
 	<entry key="LIQUID_NITROGEN">Azote Liquide</entry>
-	<entry key="MAGIC_BOX">Bote Magique</entry>
+	<entry key="MAGIC_BOX">Boîte Magique</entry>
 	<entry key="MAYAN_CALENDAR">Calendrier Maya</entry>
 	<entry key="MOTHERBOARD">Carte Mère</entry>
 	<entry key="NITROGEN">Azote</entry>
@@ -101,10 +101,11 @@
 	<entry key="TOPAZ">Topaze</entry>
 	<entry key="URANIUM">Uranium</entry>
 	<entry key="URANIUM_ROD">Lingot d'Uranium</entry>
-	<entry key="WINTER_SOCK">Chaussette de Nol</entry>
-	<entry key="WINTERFEST_GLOBE">Boule à Neige du Conte d'Hiver</entry>
-	<entry key="WINTERFEST_TOY">Jouet du Festival d'Hiver</entry>
 	<entry key="WATER">Eau</entry>
+	<entry key="WINTER_SOCK">Chaussette de Noël</entry>
+	<entry key="WINTERFEST_GLOBE">Boule À Neige du Conte d'Hiver</entry>
+	<entry key="WINTERFEST_TOY">Jouet du Festival d'Hiver</entry>
 	<entry key="WOOD">Bois</entry>
 	<entry key="YELLOW_CANDY">Bonbon Jaune</entry>
 </properties>
+

--- a/src/main/resources/items_it.xml
+++ b/src/main/resources/items_it.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
 <properties>
-	<!-- risorse per il gioco del telefono cellulare "Deep Town"
-		Italiano -->
 	<!-- resources for mobile game "Deep Town"
 		Italian -->
+	<!-- ALL TRANSLATIONS MATCH THE GAME. TRANSLATIONS MAY OR MAY
+		NOT BE ACCURATE IN ITALIAN. -->
 	<entry key="ACCUMULATOR">Accumulatore</entry>
 	<entry key="ALEXANDRITE">Alessandrite</entry>
 	<entry key="ALUMINIUM">Alluminio</entry>
@@ -48,7 +48,7 @@
 	<entry key="GREEN_LASER">Laser Verde</entry>
 	<entry key="GUNPOWDER">Polvere da Sparo</entry>
 	<entry key="HAIR_COMB">Pettini</entry>
-	<entry key="HELIUM_3">Elio-3</entry>
+	<entry key="HELIUM_3">Elio 3</entry>
 	<entry key="HYDROGEN">Idrogeno</entry>
 	<entry key="INSULATED_WIRE">Cavo Isolato</entry>
 	<entry key="IRON">Ferro</entry>
@@ -97,15 +97,13 @@
 	<entry key="SULPHURIC_ACID">Acido Solforico</entry>
 	<entry key="TITANIUM">Titanio</entry>
 	<entry key="TITANIUM_BAR">Barra di Titanio</entry>
-	<!-- The translation for Titanium Ore, below, is incorrect.
-	The translation below matches the game. The error has been reported to the developers. -->
 	<entry key="TITANIUM_ORE">Barra di Titanio</entry>
 	<entry key="TOPAZ">Topazio</entry>
 	<entry key="URANIUM">Uranio</entry>
 	<entry key="URANIUM_ROD">Barra di Uranio</entry>
 	<entry key="WATER">Acqua</entry>
 	<entry key="WINTER_SOCK">Calza di Natale</entry>
-	<entry key="WINTERFEST_GLOBE">Sfera delle Fiabe Invernali</entry>
+	<entry key="WINTERFEST_GLOBE">Sfera Delle Fiabe Invernali</entry>
 	<entry key="WINTERFEST_TOY">Giocattolo Festa Invernale</entry>
 	<entry key="WOOD">Legno</entry>
 	<entry key="YELLOW_CANDY">Dolcetto Giallo</entry>

--- a/src/main/resources/items_it.xml
+++ b/src/main/resources/items_it.xml
@@ -2,8 +2,8 @@
 <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
 <properties>
 	<!-- risorse per il gioco del telefono cellulare "Deep Town"
-		Italiano
-	resources for mobile game "Deep Town"
+		Italiano -->
+	<!-- resources for mobile game "Deep Town"
 		Italian -->
 	<entry key="ACCUMULATOR">Accumulatore</entry>
 	<entry key="ALEXANDRITE">Alessandrite</entry>

--- a/src/main/resources/items_pt.xml
+++ b/src/main/resources/items_pt.xml
@@ -14,7 +14,7 @@
 	<entry key="ALUMINIUM">Alumínio</entry>
 	<entry key="ALUMINIUM_BAR">Barra de Alumínio</entry>
 	<entry key="ALUMINIUM_BOTTLE">Garrafa de Alumínio</entry>
-	<entry key="AMBER">Âmber</entry>
+	<entry key="AMBER">Âmbar</entry>
 	<entry key="AMBER_BRACELET">Bracelete de Âmbar</entry>
 	<entry key="AMBER_CHARGER">Carregador de Âmbar</entry>
 	<entry key="AMBER_INSULATION">Isolamento de Âmber</entry>
@@ -73,7 +73,7 @@
 	<entry key="PLASTIC">Plástico</entry>
 	<entry key="PLATINUM">Platina</entry>
 	<entry key="POLISHED_ALEXANDRITE">Alexandrita Polida</entry>
-	<entry key="POLISHED_AMBER">Âmber Lapidado</entry>
+	<entry key="POLISHED_AMBER">Âmbar Lapidado</entry>
 	<entry key="POLISHED_AMETHYST">Ametista Polida</entry>
 	<entry key="POLISHED_DIAMOND">Diamante Polido</entry>
 	<entry key="POLISHED_EMERALD">Esmeralda Lapidada</entry>

--- a/src/main/resources/strings_en.xml
+++ b/src/main/resources/strings_en.xml
@@ -37,7 +37,7 @@
 	<entry key="GROUP_REMOVE_UNKNOWN">Tell me the name of the group and the name of the resource to remove.</entry>
 	<!-- -->
 	<!-- report headers -->
-	<entry key="USERS_LIST_HEADER">Guild members</entry>
+	<entry key="USERS_LIST_HEADER">Guild members (%d)</entry>
 	<entry key="OLDEST_STOCK">Age</entry>
 	<entry key="USER">User</entry>
 	<entry key="POPULATED">Populated</entry>

--- a/src/main/resources/strings_pt.xml
+++ b/src/main/resources/strings_pt.xml
@@ -15,7 +15,7 @@
 	<!-- mensagens de erro para os utilizadores -->
 	<!-- error messages for users -->
 	<entry key="ERROR_UNKNOWN">Ooooops... Eu encontrei um erro. Por favor não me bata! --> "%s"</entry>
-	<entry key="RESOURCE_AND_USER_UNKNOWN">Eu não conheço nem um utilizador nem um recurso com esse nome.</entry>
+	<entry key="RESOURCE_AND_USER_UNKNOWN">Eu não conheço nem um utilizador nem um recurso com esse nome. =(</entry>
 	<entry key="ALREADY_KNOW">Eu já sei disso.</entry>
 	<entry key="RESOURCE_UNKNOWN">Eu não conheço este recurso. =(</entry>
 	<entry key="DO_NOT_KNOW_ABOUT">Eu não sei nada acerca disto: %s</entry>
@@ -46,7 +46,7 @@
 	<!-- -->
 	<!-- cabeçalhos de relatório -->
 	<!-- report headers -->
-	<entry key="USERS_LIST_HEADER">Membros da guilda</entry>
+	<entry key="USERS_LIST_HEADER">Membros da guilda (%d)</entry>
 	<entry key="OLDEST_STOCK">Idade</entry>
 	<entry key="USER">Utilizador</entry>
 	<entry key="POPULATED">Indexados</entry>


### PR DESCRIPTION
Numerous, though somewhat random, edits to documentation.
Used Deep Town's own i18n files to update items_XX.xml files for all 6 languages that use the Latin alphabet and that Deep Town supports.